### PR TITLE
feat(cli): set terminalWidth as wrap to avoid work break on help

### DIFF
--- a/@commitlint/cli/src/cli.test.ts
+++ b/@commitlint/cli/src/cli.test.ts
@@ -519,34 +519,24 @@ test('should print help', async () => {
 		[input] reads from stdin if --edit, --env, --from and --to are omitted
 
 		Options:
-		  -c, --color          toggle colored output           [boolean] [default: true]
-		  -g, --config         path to the config file                          [string]
-		      --print-config   print resolved config
-		                                          [string] [choices: "", "text", "json"]
-		  -d, --cwd            directory to execute in
-		                                         [string] [default: (Working Directory)]
-		  -e, --edit           read last commit message from the specified file or fallb
-		                       acks to ./.git/COMMIT_EDITMSG                    [string]
-		  -E, --env            check message in the file at path given by environment va
-		                       riable value                                     [string]
-		  -x, --extends        array of shareable configurations to extend       [array]
-		  -H, --help-url       help url in error message                        [string]
-		  -f, --from           lower end of the commit range to lint; applies if edit=fa
-		                       lse                                              [string]
-		      --git-log-args   additional git log arguments as space separated string, e
-		                       xample '--first-parent --cherry-pick'            [string]
-		  -o, --format         output format of the results                     [string]
-		  -p, --parser-preset  configuration preset to use for conventional-commits-pars
-		                       er                                               [string]
-		  -q, --quiet          toggle console output          [boolean] [default: false]
-		  -t, --to             upper end of the commit range to lint; applies if edit=fa
-		                       lse                                              [string]
-		  -V, --verbose        enable verbose output for reports without problems
-		                                                                       [boolean]
-		  -s, --strict         enable strict mode; result code 2 for warnings, 3 for err
-		                       ors                                             [boolean]
-		  -v, --version        display version information                     [boolean]
-		  -h, --help           Show help                                       [boolean]"
+		  -c, --color          toggle colored output  [boolean] [default: true]
+		  -g, --config         path to the config file  [string]
+		      --print-config   print resolved config  [string] [choices: "", "text", "json"]
+		  -d, --cwd            directory to execute in  [string] [default: (Working Directory)]
+		  -e, --edit           read last commit message from the specified file or fallbacks to ./.git/COMMIT_EDITMSG  [string]
+		  -E, --env            check message in the file at path given by environment variable value  [string]
+		  -x, --extends        array of shareable configurations to extend  [array]
+		  -H, --help-url       help url in error message  [string]
+		  -f, --from           lower end of the commit range to lint; applies if edit=false  [string]
+		      --git-log-args   additional git log arguments as space separated string, example '--first-parent --cherry-pick'  [string]
+		  -o, --format         output format of the results  [string]
+		  -p, --parser-preset  configuration preset to use for conventional-commits-parser  [string]
+		  -q, --quiet          toggle console output  [boolean] [default: false]
+		  -t, --to             upper end of the commit range to lint; applies if edit=false  [string]
+		  -V, --verbose        enable verbose output for reports without problems  [boolean]
+		  -s, --strict         enable strict mode; result code 2 for warnings, 3 for errors  [boolean]
+		  -v, --version        display version information  [boolean]
+		  -h, --help           Show help  [boolean]"
 	`);
 });
 

--- a/@commitlint/cli/src/cli.ts
+++ b/@commitlint/cli/src/cli.ts
@@ -146,6 +146,12 @@ const cli = yargs(process.argv.slice(2))
 	)
 	.strict();
 
+/**
+ * avoid description words to be divided in new lines when there is enough space
+ * @see https://github.com/conventional-changelog/commitlint/pull/3850#discussion_r1472251234
+ */
+cli.wrap(cli.terminalWidth());
+
 main(cli.argv).catch((err) => {
 	setTimeout(() => {
 		if (err.type === pkg.name) {


### PR DESCRIPTION
follow up of https://github.com/conventional-changelog/commitlint/pull/3850#discussion_r1477415892